### PR TITLE
Use correct version of protoc-gen-go for the version of protoc specified

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -50,11 +50,7 @@ jobs:
           GOPATH: ${{ env.TOOLS_DIR }}
         run: |
           cd ${{ env.TOOLS_DIR }} && curl -sS -L https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOC_VERSION }}/protoc-${{ env.PROTOC_VERSION }}-linux-x86_64.zip -o protoc.zip && unzip -q protoc.zip
-
-          go get -d -u github.com/golang/protobuf/protoc-gen-go
-          git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout v${{ env.PROTOC_GEN_GO_VERSION }}
-          go install github.com/golang/protobuf/protoc-gen-go
-
+          GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v${{ env.PROTOC_GEN_GO_VERSION }}
           go get github.com/golang/mock/mockgen
           go get golang.org/x/tools/cmd/goimports
       - name: Generate stubs and mocks


### PR DESCRIPTION
The version of protoc has been set to 3.9.1 for compatibility with the version of the grpc libraries used by Quorum.  Generated go code from using the latest HEAD version of protoc-gen-go results in compilation errors when Quorum tries to use the generated code.  Setting the correct version of protoc-gen-go (i.e. the latest available version when protoc@v3.9.1 was released) ensures the generated code is correct for use by Quorum.